### PR TITLE
Update attribute data types (Game class)

### DIFF
--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -1,7 +1,7 @@
 {
   "RSpec": {
     "coverage": {
-      "/Users/reidmiller/Documents/turing/1mod/projects/futbol/lib/game.rb": {
+      "/Users/cp/turing/1mod/projects/futbol/lib/game.rb": {
         "lines": [
           1,
           1,
@@ -20,7 +20,7 @@
           null
         ]
       },
-      "/Users/reidmiller/Documents/turing/1mod/projects/futbol/lib/team.rb": {
+      "/Users/cp/turing/1mod/projects/futbol/lib/team.rb": {
         "lines": [
           1,
           1,
@@ -35,7 +35,7 @@
           null
         ]
       },
-      "/Users/reidmiller/Documents/turing/1mod/projects/futbol/lib/stat_tracker.rb": {
+      "/Users/cp/turing/1mod/projects/futbol/lib/stat_tracker.rb": {
         "lines": [
           1,
           null,
@@ -87,7 +87,7 @@
           null
         ]
       },
-      "/Users/reidmiller/Documents/turing/1mod/projects/futbol/spec/stat_tracker_spec.rb": {
+      "/Users/cp/turing/1mod/projects/futbol/spec/stat_tracker_spec.rb": {
         "lines": [
           1,
           null,
@@ -113,7 +113,7 @@
           null
         ]
       },
-      "/Users/reidmiller/Documents/turing/1mod/projects/futbol/spec/team_spec.rb": {
+      "/Users/cp/turing/1mod/projects/futbol/spec/team_spec.rb": {
         "lines": [
           1,
           null,
@@ -149,6 +149,6 @@
         ]
       }
     },
-    "timestamp": 1677641389
+    "timestamp": 1677682667
   }
 }

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -14,7 +14,7 @@
       <img src="./assets/0.12.3/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2023-02-28T20:29:49-07:00">2023-02-28T20:29:49-07:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2023-03-01T09:57:47-05:00">2023-03-01T09:57:47-05:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">
@@ -71,7 +71,7 @@
       <tbody>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#ab5fab5e9b059260b0cf1a05d71d451743fcbec5" class="src_link" title="lib/game.rb">lib/game.rb</a></td>
+            <td class="strong t-file__name"><a href="#2a8fe4f9a3a15c41e25fc7c481c9e010c158a7da" class="src_link" title="lib/game.rb">lib/game.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">15</td>
             <td class="cell--number">12</td>
@@ -82,7 +82,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#85816d730e3f700246869fe70c0d02b8f26ebada" class="src_link" title="lib/stat_tracker.rb">lib/stat_tracker.rb</a></td>
+            <td class="strong t-file__name"><a href="#d3b9608b8e57f05d57344d6a4468de0832a00e05" class="src_link" title="lib/stat_tracker.rb">lib/stat_tracker.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">48</td>
             <td class="cell--number">35</td>
@@ -93,7 +93,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#ccb7b572ec5ae91c215188f22515498015487280" class="src_link" title="lib/team.rb">lib/team.rb</a></td>
+            <td class="strong t-file__name"><a href="#5a374fae65e567e0fa22cd046b75a6cf9b2f7d39" class="src_link" title="lib/team.rb">lib/team.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">11</td>
             <td class="cell--number">8</td>
@@ -104,7 +104,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#683a568d230aa660218b13bcffaa024991498609" class="src_link" title="spec/stat_tracker_spec.rb">spec/stat_tracker_spec.rb</a></td>
+            <td class="strong t-file__name"><a href="#604c19e6d2e83022e53efeb4c28259258cb79b1b" class="src_link" title="spec/stat_tracker_spec.rb">spec/stat_tracker_spec.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">22</td>
             <td class="cell--number">11</td>
@@ -115,7 +115,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#efa58c7a41e8455e691818de5304a4fbb39776ef" class="src_link" title="spec/team_spec.rb">spec/team_spec.rb</a></td>
+            <td class="strong t-file__name"><a href="#6305b0874e21eadef79b12207d25b09ab2950762" class="src_link" title="spec/team_spec.rb">spec/team_spec.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">31</td>
             <td class="cell--number">18</td>
@@ -142,7 +142,7 @@
 
       <div class="source_files">
       
-        <div class="source_table" id="ab5fab5e9b059260b0cf1a05d71d451743fcbec5">
+        <div class="source_table" id="2a8fe4f9a3a15c41e25fc7c481c9e010c158a7da">
   <div class="header">
     <h3>lib/game.rb</h3>
     <h4>
@@ -285,7 +285,7 @@
 
             
 
-            <code class="ruby">    @away_goals = details[:away_goals]</code>
+            <code class="ruby">    @away_goals = details[:away_goals].to_i</code>
           </li>
         </div>
       
@@ -296,7 +296,7 @@
 
             
 
-            <code class="ruby">    @home_goals = details[:home_goals]</code>
+            <code class="ruby">    @home_goals = details[:home_goals].to_i</code>
           </li>
         </div>
       
@@ -338,7 +338,7 @@
 </div>
 
       
-        <div class="source_table" id="85816d730e3f700246869fe70c0d02b8f26ebada">
+        <div class="source_table" id="d3b9608b8e57f05d57344d6a4468de0832a00e05">
   <div class="header">
     <h3>lib/stat_tracker.rb</h3>
     <h4>
@@ -897,7 +897,7 @@
 </div>
 
       
-        <div class="source_table" id="ccb7b572ec5ae91c215188f22515498015487280">
+        <div class="source_table" id="5a374fae65e567e0fa22cd046b75a6cf9b2f7d39">
   <div class="header">
     <h3>lib/team.rb</h3>
     <h4>
@@ -1049,7 +1049,7 @@
 </div>
 
       
-        <div class="source_table" id="683a568d230aa660218b13bcffaa024991498609">
+        <div class="source_table" id="604c19e6d2e83022e53efeb4c28259258cb79b1b">
   <div class="header">
     <h3>spec/stat_tracker_spec.rb</h3>
     <h4>
@@ -1322,7 +1322,7 @@
 </div>
 
       
-        <div class="source_table" id="efa58c7a41e8455e691818de5304a4fbb39776ef">
+        <div class="source_table" id="6305b0874e21eadef79b12207d25b09ab2950762">
   <div class="header">
     <h3>spec/team_spec.rb</h3>
     <h4>

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -8,8 +8,8 @@ class Game
     @date_time = details[:date_time]
     @away_team_id = details[:away_team_id]
     @home_team_id = details[:home_team_id]
-    @away_goals = details[:away_goals]
-    @home_goals = details[:home_goals]
+    @away_goals = details[:away_goals].to_i
+    @home_goals = details[:home_goals].to_i
     @venue = details[:venue]
   end
 end

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -27,8 +27,8 @@ describe Game do
       expect(@test_game.date_time).to eq("5/16/13")
       expect(@test_game.away_team_id).to eq("3")
       expect(@test_game.home_team_id).to eq("6")
-      expect(@test_game.away_goals).to eq("2")
-      expect(@test_game.home_goals).to eq("3")
+      expect(@test_game.away_goals).to eq(2)
+      expect(@test_game.home_goals).to eq(3)
       expect(@test_game.venue).to eq("Toyota Stadium")
     end
   end


### PR DESCRIPTION
This PR updates the home and away goals attributes on the game class to be stored as integers, and updates the tests in the Game spec file to expect an integer value.


Note: for now, I kept team IDs and other identifying information as strings for matching purposes, but we can discuss if you all want to try something else.

The Team class did not have any attributes that I thought we needed to update the data types for. When the Game/Teams class is added I can go in and update those data types too.