### PR TITLE
Fix/edit game stats methods

### DIFF
--- a/lib/game_stats.rb
+++ b/lib/game_stats.rb
@@ -50,14 +50,14 @@ module GameStats
     number_of_games = total_games(@games)
     number_of_goals = @games.sum {|game| total_goals(game)}
 
-    number_of_goals.fdiv(number_of_games)
+    number_of_goals.fdiv(number_of_games).round(2)
   end
 
   def average_goals_by_season
     result = Hash.new(0)
     games_by_season = @games.group_by{|game| game.season}
     games_by_season.each do |season, games|
-      result[season] += (games.sum{|game| total_goals(game)}).fdiv(total_games(games))
+      result[season] += (games.sum{|game| total_goals(game)}).fdiv(total_games(games)).round(2)
     end
     result
   end

--- a/lib/game_stats.rb
+++ b/lib/game_stats.rb
@@ -53,7 +53,7 @@ module GameStats
     number_of_goals.fdiv(number_of_games)
   end
 
-  def average_goals_per_season
+  def average_goals_by_season
     result = Hash.new(0)
     games_by_season = @games.group_by{|game| game.season}
     games_by_season.each do |season, games|

--- a/spec/game_stats_spec.rb
+++ b/spec/game_stats_spec.rb
@@ -40,7 +40,7 @@ describe GameStats do
 
     expect(@stat_tracker.lowest_total_score).to eq(1)
   end
-  
+
   it 'can determine the average goals per game' do
     @stat_tracker.games = @test_games
 
@@ -52,10 +52,10 @@ describe GameStats do
     @stat_tracker.games = @test_games
     expected = {"20122013" => 3.7}
 
-    expect(@stat_tracker.average_goals_per_season).to be_a Hash
-    expect(@stat_tracker.average_goals_per_season.keys[0]).to be_a String
-    expect(@stat_tracker.average_goals_per_season.values[0]).to be_a Float
-    expect(@stat_tracker.average_goals_per_season).to eq(expected)
+    expect(@stat_tracker.average_goals_by_season).to be_a Hash
+    expect(@stat_tracker.average_goals_by_season.keys[0]).to be_a String
+    expect(@stat_tracker.average_goals_by_season.values[0]).to be_a Float
+    expect(@stat_tracker.average_goals_by_season).to eq(expected)
   end
 
   it 'can determine percentage of home wins' do


### PR DESCRIPTION
This PR fixes a method name (Average Goals **By** Season instead of Average Goals **Per** Season) and adjusts two existing methods to round float return values to two decimal places.

This addresses issues raised by running the Spec Harness, and these methods are now passing the tests in the harness.