### PR TITLE
Refactor to add arguments to Game_Team

### DIFF
--- a/lib/game_team.rb
+++ b/lib/game_team.rb
@@ -1,19 +1,20 @@
 class GameTeam
-  attr_reader :game_id, 
-              :team_id, 
-              :hoa, 
-              :result, 
-              :settled_in, 
-              :head_coach, 
-              :goals, 
-              :shots, 
+  attr_reader :game_id,
+              :team_id,
+              :hoa,
+              :result,
+              :settled_in,
+              :head_coach,
+              :goals,
+              :shots,
               :tackles,
               :pim,
               :power_play_opportunities,
               :power_play_goals,
               :face_off_win_percentage,
               :give_aways,
-              :take_aways
+              :take_aways,
+              :season
 
   def initialize(details)
     @game_id = details[:game_id]
@@ -31,5 +32,6 @@ class GameTeam
     @face_off_win_percentage = details[:faceoffwinpercentage].to_f
     @give_aways = details[:giveaways].to_i
     @take_aways = details[:takeaways].to_i
+    @season = details[:season]
   end
 end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -18,6 +18,7 @@ class StatTracker
     @games = []
     @teams = []
     @game_teams = []
+    @game_seasons = {}
     @games_data = parse_games_data(csv_games_data)
     @game_team_data = parse_game_team_data(csv_game_team_data)
     @team_data = parse_team_data(csv_team_data)
@@ -43,6 +44,7 @@ class StatTracker
       data_hash[:home_goals] = row[:home_goals]
       data_hash[:venue] = row[:venue]
       @games << Game.new(data_hash)
+      @game_seasons[row[:game_id]] = row[:season]
     end
   end
 
@@ -77,6 +79,7 @@ class StatTracker
       data_hash[:faceoffwinpercentage] = row[:faceoffwinpercentage]
       data_hash[:giveaways] = row[:giveaways]
       data_hash[:takeaways] = row[:takeaways]
+      data_hash[:season] = @game_seasons[row[:game_id]]
       @game_teams << GameTeam.new(data_hash)
     end
   end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -19,9 +19,9 @@ class StatTracker
     @teams = []
     @game_teams = []
     @game_seasons = {}
-    @games_data = parse_games_data(csv_games_data)
-    @game_team_data = parse_game_team_data(csv_game_team_data)
-    @team_data = parse_team_data(csv_team_data)
+    parse_games_data(csv_games_data)
+    parse_game_team_data(csv_game_team_data)
+    parse_team_data(csv_team_data)
   end
 
   def self.from_csv(locations)

--- a/spec/game_team_spec.rb
+++ b/spec/game_team_spec.rb
@@ -36,6 +36,7 @@ describe GameTeam do
       expect(@test_game_teams.face_off_win_percentage).to eq(44.8)
       expect(@test_game_teams.give_aways).to eq(17)
       expect(@test_game_teams.take_aways).to eq(7)
+      expect(@test_game_teams.season).to eq('20122013')
     end
   end
 end


### PR DESCRIPTION
This PR adds the season as an attribute on the Game Team class. 

The attribute's value is set during initialization, using a hash that is built up when parsing the Game data in the StatTracker class.

The PR also adds a test to check that the value is being properly assigned to the Game Team instances when created.

NOTE: this attribute is not yet being used in any of our methods in either the main modules or the Helper - running out of steam to play with that tonight, but can jump in again on Sunday (or feel free to do that!).  I did do some manual checking to make sure that the frequency that each season showed up in the original Game data matched the frequency as assigned by us in the Game Team data.